### PR TITLE
Ignore comments on source code

### DIFF
--- a/lib/swoop/entity_parser.rb
+++ b/lib/swoop/entity_parser.rb
@@ -34,9 +34,9 @@ module Swoop
     TYPE_EXTENSION = 'extension'
     TYPE_CATEGORY = 'category'
 
-    SWIFT_CLASS = /class\s*(\w+)/
-    SWIFT_STRUCT = /struct\s*(\w+)/
-    SWIFT_EXT = /extension\s*(\w+)/
+    SWIFT_CLASS = /^class\s*(\w+)/
+    SWIFT_STRUCT = /^struct\s*(\w+)/
+    SWIFT_EXT = /^extension\s*(\w+)/
     def parse_swift
       classes = file_content.scan(SWIFT_CLASS).flatten.map { |e| Entity.new(e, LANG_SWIFT, TYPE_CLASS) }
       structs = file_content.scan(SWIFT_STRUCT).flatten.map { |e| Entity.new(e, LANG_SWIFT, TYPE_STRUCT) }
@@ -45,10 +45,10 @@ module Swoop
       [ *classes, *structs, *extensions ]
     end
 
-    OBJC_CLASS = /@interface\s*(\w+)\s*:/
-    OBJC_CATEGORY = /@interface\s*(\w+)\s*\((.*)\)/
-    OBJC_STRUCT = /typedef\s*struct\s*{.*?}\s*(\w*)/m
-    OBJC_STRUCT2 = /struct\s*(\w+)/
+    OBJC_CLASS = /^@interface\s*(\w+)\s*:/
+    OBJC_CATEGORY = /^@interface\s*(\w+)\s*\((.*)\)/
+    OBJC_STRUCT = /^typedef\s*struct\s*{.*?}\s*(\w*)/m
+    OBJC_STRUCT2 = /^struct\s*(\w+)/
     def parse_objc
       classes = file_content.scan(OBJC_CLASS).flatten.map { |e| Entity.new(e, LANG_OBJC, TYPE_CLASS) }
       categories = file_content.scan(OBJC_CATEGORY)

--- a/lib/swoop/entity_parser.rb
+++ b/lib/swoop/entity_parser.rb
@@ -34,29 +34,29 @@ module Swoop
     TYPE_EXTENSION = 'extension'
     TYPE_CATEGORY = 'category'
 
-    SWIFT_CLASS = /^class\s*(\w+)/
-    SWIFT_STRUCT = /^struct\s*(\w+)/
-    SWIFT_EXT = /^extension\s*(\w+)/
+    SWIFT_CLASS = 'class\s*(\w+)'
+    SWIFT_STRUCT = 'struct\s*(\w+)'
+    SWIFT_EXT = 'extension\s*(\w+)'
     def parse_swift
-      classes = file_content.scan(SWIFT_CLASS).flatten.map { |e| Entity.new(e, LANG_SWIFT, TYPE_CLASS) }
-      structs = file_content.scan(SWIFT_STRUCT).flatten.map { |e| Entity.new(e, LANG_SWIFT, TYPE_STRUCT) }
-      extensions = file_content.scan(SWIFT_EXT).flatten.map { |e| Entity.new(e, LANG_SWIFT, TYPE_EXTENSION) }
+      classes = filter(SWIFT_CLASS).map { |e| Entity.new(e, LANG_SWIFT, TYPE_CLASS) }
+      structs = filter(SWIFT_STRUCT).map { |e| Entity.new(e, LANG_SWIFT, TYPE_STRUCT) }
+      extensions = filter(SWIFT_EXT).map { |e| Entity.new(e, LANG_SWIFT, TYPE_EXTENSION) }
 
       [ *classes, *structs, *extensions ]
     end
 
-    OBJC_CLASS = /^@interface\s*(\w+)\s*:/
-    OBJC_CATEGORY = /^@interface\s*(\w+)\s*\((.*)\)/
-    OBJC_STRUCT = /^typedef\s*struct\s*{.*?}\s*(\w*)/m
-    OBJC_STRUCT2 = /^struct\s*(\w+)/
+    OBJC_CLASS = '@interface\s*(\w+)\s*:'
+    OBJC_CATEGORY = '@interface\s*(\w+)\s*\((.*)\)'
+    OBJC_STRUCT ='typedef\s*struct\s*{.*?}\s*(\w*)'
+    OBJC_STRUCT2 = 'struct\s*(\w+)'
     def parse_objc
-      classes = file_content.scan(OBJC_CLASS).flatten.map { |e| Entity.new(e, LANG_OBJC, TYPE_CLASS) }
-      categories = file_content.scan(OBJC_CATEGORY)
+      classes = filter(OBJC_CLASS).map { |e| Entity.new(e, LANG_OBJC, TYPE_CLASS) }
+      categories = filter(OBJC_CATEGORY, false)
         .map { |exts|
           exts.select { |e| !e.empty? }.join('+')
         }
         .map { |e| Entity.new(e, LANG_OBJC, (e.include?('+') ? TYPE_CATEGORY : TYPE_EXTENSION)) }
-      structs = (file_content.scan(OBJC_STRUCT) + file_content.scan(OBJC_STRUCT2)).flatten
+      structs = (filter(OBJC_STRUCT, true, Regexp::MULTILINE) + filter(OBJC_STRUCT2))
         .map { |e| Entity.new(e, LANG_OBJC, TYPE_STRUCT) }
 
       [ *classes, *structs, *categories ]
@@ -64,6 +64,18 @@ module Swoop
 
     def file_content
       @file_content ||= File.read(@filepath)
+    end
+
+    def filter(expression, should_flatten = true, options = 0)
+      # filter out comments
+      regex = Regexp.new("#{expression}", options)
+      contents = file_content.scan(regex)
+      regex_comments = Regexp.new(".*\/\/.*#{expression}", options)
+      commented = file_content.scan(regex_comments)
+
+      filtered = contents - commented
+      return filtered unless should_flatten
+      filtered.flatten
     end
   end
 

--- a/spec/entity_parser_spec.rb
+++ b/spec/entity_parser_spec.rb
@@ -82,15 +82,15 @@ describe Swoop::EntityParser do
         expect(class_names).not_to include("_SpecialViewController")
       end
 
+      it "should ignore commented categories" do
+        ext_names = subject.entities.select { |e| e.type == 'extension' }.map { |e| e.name }
+        expect(ext_names).not_to include("_SpecialViewController")
+      end
+
       it "should ignore commented structs" do
         struct_names = subject.entities.select { |e| e.type == 'struct' }.map { |e| e.name }
         expect(struct_names).not_to include("_Book")
         expect(struct_names).not_to include("_Cooordinate")
-      end
-
-      it "should ignore commented categories" do
-        ext_names = subject.entities.select { |e| e.type == 'extension' }.map { |e| e.name }
-        expect(ext_names).not_to include("_SpecialViewController")
       end
     end
   end

--- a/spec/entity_parser_spec.rb
+++ b/spec/entity_parser_spec.rb
@@ -23,6 +23,24 @@ describe Swoop::EntityParser do
       user = double(Swoop::Entity, { 'name' => 'User', 'language' => 'swift', 'type' => 'extension' })
       expect(subject.entities).to include(user)
     end
+
+    context "when commented" do
+      it "should ignore commented classes" do
+        class_names = subject.entities.select { |e| e.type == 'class' }.map { |e| e.name }
+        expect(class_names).not_to include("_User")
+        expect(class_names).not_to include("_Admin")
+      end
+
+      it "should ignore commented structs" do
+        struct_names = subject.entities.select { |e| e.type == 'struct' }.map { |e| e.name }
+        expect(struct_names).not_to include("_Position")
+      end
+
+      it "should ignore commented extension" do
+        ext_names = subject.entities.select { |e| e.type == 'extension' }.map { |e| e.name }
+        expect(ext_names).not_to include("_User")
+      end
+    end
   end
 
   context "Parsing Objective-C file" do
@@ -55,6 +73,25 @@ describe Swoop::EntityParser do
 
       struct3 = double(Swoop::Entity, { 'name' => 'Book', 'language' => 'objc', 'type' => 'struct' })
       expect(subject.entities).to include(struct3)
+    end
+
+    context "when commented" do
+      it "should ignore commented classes" do
+        class_names = subject.entities.select { |e| e.type == 'class' }.map { |e| e.name }
+        expect(class_names).not_to include("_ViewController")
+        expect(class_names).not_to include("_SpecialViewController")
+      end
+
+      it "should ignore commented structs" do
+        struct_names = subject.entities.select { |e| e.type == 'struct' }.map { |e| e.name }
+        expect(struct_names).not_to include("_Book")
+        expect(struct_names).not_to include("_Cooordinate")
+      end
+
+      it "should ignore commented categories" do
+        ext_names = subject.entities.select { |e| e.type == 'extension' }.map { |e| e.name }
+        expect(ext_names).not_to include("_SpecialViewController")
+      end
     end
   end
 

--- a/spec/fixture/Swoop/Swoop/User.swift
+++ b/spec/fixture/Swoop/Swoop/User.swift
@@ -13,6 +13,8 @@ struct Position {
     var y : Double
 }
 
+// struct _Position {}
+
 class User {
     let firstName : String = ""
     let lastName : String = ""
@@ -20,8 +22,16 @@ class User {
 
 class Admin : User { }
 
+// class _User {
+//     let firstName : String = ""
+// }
+//
+// class _Admin : User { }
+
 extension User {
     var fullName : String {
         return firstName + " " + lastName
     }
 }
+
+// extension _User {}

--- a/spec/fixture/Swoop/Swoop/User.swift
+++ b/spec/fixture/Swoop/Swoop/User.swift
@@ -20,13 +20,13 @@ class User {
     let lastName : String = ""
 }
 
-class Admin : User { }
+private class Admin : User { }
 
-// class _User {
+// private class _User {
 //     let firstName : String = ""
 // }
 //
-// class _Admin : User { }
+//class _Admin : User { }
 
 extension User {
     var fullName : String {

--- a/spec/fixture/Swoop/Swoop/ViewController.h
+++ b/spec/fixture/Swoop/Swoop/ViewController.h
@@ -16,7 +16,7 @@
 
 @end
 
-@interface SpecialViewController : ViewController
+  @interface SpecialViewController : ViewController
 
 @end
 

--- a/spec/fixture/Swoop/Swoop/ViewController.h
+++ b/spec/fixture/Swoop/Swoop/ViewController.h
@@ -20,6 +20,14 @@
 
 @end
 
+// @interface _ViewController : UIViewController
+//
+// @end
+//
+// @interface _SpecialViewController : _ViewController
+//
+// @end
+
 @interface SpecialViewController (Extension)
 
 @end
@@ -27,6 +35,9 @@
 @interface SpecialViewController ()
 
 @end
+
+// @interface _SpecialViewController ()
+// @end
 
 typedef struct {
     unsigned char red;
@@ -45,3 +56,15 @@ typedef struct {
     int lat,
     int long,
 } Coordinate;
+
+// struct _Book
+// {
+//    NSString *title;
+//    NSString *author;
+//    int book_id;
+// } book;
+
+// typedef struct {
+//     int lat,
+//     int long,
+// } _Coordinate;


### PR DESCRIPTION
Addressing #12.

Tried using regex's [negative lookbehind](http://www.regular-expressions.info/lookaround.html#lookbehind) but failed since it needs to know exact characters. Instead, using all contents and all commented contents and subtract them.